### PR TITLE
Require htmllint-cli >= 0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@ Before using this plugin, you must ensure that `htmllint` is installed on your s
    ```
    npm install -g htmllint-cli
    ```
+   Or install locally in your project folder (you must have a `package.json` file for the local version to be used):
+   ```
+   npm install --save-dev htmllint-cli
+   ```
 
 1. If you are using `nvm` and `zsh`, ensure that the line to load `nvm` is in `.zshenv` and not `.zshrc`.
 
 1. If you are using `zsh` and `oh-my-zsh`, do not load the `nvm` plugin for `oh-my-zsh`.
 
 
-**Note:** This plugin requires `htmllint` 0.0.4 or later.
+**Note:** This plugin requires `htmllint` 0.0.7 or later.
 
 ### Linter configuration
 In order for `htmllint` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.

--- a/linter.py
+++ b/linter.py
@@ -22,5 +22,5 @@ class Htmllint(NodeLinter):
     config_file = ('--rc', '.htmllintrc')
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.0.4'
+    version_requirement = '>= 0.0.7'
     regex = r'^.+: line (?P<line>\d+), col (?P<col>\d+), (?P<message>.+)'


### PR DESCRIPTION
The changes I made in #2 will only work with `htmllint-cli >= 0.0.7`. This PR changes the code and README to require this version of `htmllint-cli`. 